### PR TITLE
Remove outdated fantasypros filters

### DIFF
--- a/chrome/contentscript.js
+++ b/chrome/contentscript.js
@@ -1402,15 +1402,7 @@ function fetchPositionData(position, type, cb) {
         source_site = 'https://www.fantasypros.com/nfl/rankings/' + ros_url + rank_ppr + position + '.php?export=xls';
     }
     else if (off_positions_proj.indexOf(position) > -1) {
-        //TODO: doublecheck this on season start. cant just exclude people.
-        var rankers = '11:44:45:71:73:152:469';
-        if (siteType == "espn") {
-            rankers = '11:44:45:73:152:469';
-        }
-        else if (siteType == "yahoo") {
-            rankers = '11:44:45:71:73:152';
-        }
-        source_site = 'https://www.fantasypros.com/nfl/projections/' + position + '.php?filters=' + rankers + '&export=xls&week=' + current_week;
+        source_site = 'https://www.fantasypros.com/nfl/projections/' + position + '.php?export=xls&week=' + current_week;
     }
     else {
         //TODO delay fantasy sharks, maybe find some way to only loop over each position when the relevant calls are done

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "FantasyPlus",
   "short_name": "FantasyPlus",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "manifest_version": 2,
   "description": "Adds weekly projections/stats from FantasyPros (PFF, CBS, NumberFire, etc.) and FantasySharks (for D/ST and IDP) to fantasy sites.",
   "icons": {

--- a/firefox/contentscript.js
+++ b/firefox/contentscript.js
@@ -791,18 +791,10 @@ function fetchPositionData(position, type, cb) {
             ros_url = 'ros-';
         }
         //TODO: filters here?
-        source_site = 'http://www.fantasypros.com/nfl/rankings/' + ros_url + rank_ppr + position + '.php?export=xls';
+        source_site = 'https://www.fantasypros.com/nfl/rankings/' + ros_url + rank_ppr + position + '.php?export=xls';
     }
     else if (off_positions_proj.indexOf(position) > -1) {
-        //TODO: doublecheck this on season start. cant just exclude people.
-        var rankers = '11:44:45:71:73:152:469';
-        if (siteType == "espn") {
-            rankers = '11:44:45:73:152:469';
-        }
-        else if (siteType == "yahoo") {
-            rankers = '11:44:45:71:73:152';
-        }
-        source_site = 'http://www.fantasypros.com/nfl/projections/' + position + '.php?filters=' + rankers + '&export=xls&week=' + current_week;
+        source_site = 'https://www.fantasypros.com/nfl/projections/' + position + '.php?export=xls&week=' + current_week;
     }
     else {
         //TODO delay fantasy sharks, maybe find some way to only loop over each position when the relevant calls are done

--- a/firefox/package.json
+++ b/firefox/package.json
@@ -1,7 +1,7 @@
 {
   "title": "FantasyPlus",
   "name": "FantasyPlus",
-  "version": "2.0",
+  "version": "2.0.1",
   "description": "Adds weekly projections/stats from FantasyPros (PFF, CBS, NumberFire, etc.) and FantasySharks (for D/ST and IDP) to fantasy sites.",
   "main": "contentscript.js",
   "author": "Brett Woodward",


### PR DESCRIPTION
The filters for FantasyPros projections were from the 2015 season, so I've removed them so projections load with the consensus of all active sources.